### PR TITLE
Internal DNS fix

### DIFF
--- a/templates/portworx/0/docker-compose.yml
+++ b/templates/portworx/0/docker-compose.yml
@@ -1,5 +1,6 @@
 portworx:
   labels:
+    io.rancher.container.dns: 'true'
     io.rancher.container.create_agent: 'true'
     io.rancher.scheduler.global: 'true'
     io.rancher.container.pull_image: 'always'


### PR DESCRIPTION
Because container have host networking it wouldn't be able to access rancher internal DNS server so access to the ETCD by DNS/FQDN name wouldn't work.